### PR TITLE
Fix AbortSignal undefined error

### DIFF
--- a/admin-system-html/js/api.js
+++ b/admin-system-html/js/api.js
@@ -277,7 +277,9 @@ async function fetchData(sheet = 'all') {
             'Accept': 'application/json'
           },
           body: formBody,
-          signal: AbortSignal.timeout ? AbortSignal.timeout(CONFIG.DEFAULT_TIMEOUT) : undefined
+          signal: (typeof AbortSignal !== 'undefined' && AbortSignal.timeout)
+            ? AbortSignal.timeout(CONFIG.DEFAULT_TIMEOUT)
+            : undefined
         });
         
         if (!response.ok) {


### PR DESCRIPTION
## Summary
- guard against missing `AbortSignal.timeout` when fetching data

## Testing
- `node --check admin-system-html/js/api.js`
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_683fcd557d188322abc068cf7d75952a